### PR TITLE
RV-711 Backcheck Prices Support

### DIFF
--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -61,7 +61,8 @@ module SIX
     def fetch_mini_historical_prices(security_with_instrument_id)
       instrument_ids = security_with_instrument_id.map{ |fund_class| fund_class[:instrument_identifier]}
       instruments = SIX::InstrumentList.new(instrument_ids)
-      prices = fetch_prices(instruments, '12,0,0;12,0,1;12,0,2;12,0,3')
+      prices_list = fetch_prices(instruments, '12,0,0;12,0,1;12,0,2;12,0,3')
+      prices_list.prices
     end
 
     def verify_isin_currency_existence(isin, currency)

--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -58,6 +58,12 @@ module SIX
       result
     end
 
+    def fetch_mini_historical_prices(security_with_instrument_id)
+      instrument_ids = security_with_instrument_id.map{ |fund_class| fund_class[:instrument_identifier]}
+      instruments = SIX::InstrumentList.new(instrument_ids)
+      prices = fetch_prices(instruments, '12,0,0;12,0,1;12,0,2;12,0,3')
+    end
+
     def verify_isin_currency_existence(isin, currency)
       if isin.blank? or currency.blank?
         raise Exception, "ISIN: #{isin} or Currency: #{currency} is empty!"
@@ -71,11 +77,11 @@ module SIX
     end
 
     # returns PriceList Object
-    def fetch_prices(instruments)
+    def fetch_prices(instruments, pk= '12,0,0')
       instruments_params = instruments.price_request_params
       params = instruments_params.merge({
         ml: 'avail',
-        pk: '12,0,0',  #12,0,0 means return price value only according to table 701
+        pk: pk,  #12,0,0 means return price value only according to table 701
         psk: 'none',
         })
       prices = request('getListingData', params)['IL']['I']

--- a/lib/six/price_list.rb
+++ b/lib/six/price_list.rb
@@ -3,7 +3,19 @@ module SIX
     attr_accessor :prices
 
     def initialize(data)
-      @prices = Array.wrap(data).map{ |item| Price.new(item['P'], item['k']) }
+      @prices = Array.wrap(data).map do |item|
+        if item['P'].class == Array
+          prices = []
+          item['P'].each do |price|
+            price_parsed = Price.new(price, item['k'])
+            prices << price_parsed if price_parsed.value
+          end
+          prices
+        else
+          Price.new(item['P'], item['k'])
+        end
+
+      end
     end
 
     # returns Price object

--- a/lib/six/version.rb
+++ b/lib/six/version.rb
@@ -1,3 +1,3 @@
 module SIX
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
### Summary of Changes:

- Support  mini-historical prices in getListingData functionality by SIX. by using keys 12,0,0;12,0,1;12,0,2;12,0,3 we fetch last 3-4 prices.