### PR TITLE
RV-2020 Improve SIX error handling

### DIFF
--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -86,7 +86,7 @@ module SIX
         })
       response = request('getListingData', params)
       response.errors.each do |error|
-        @exceptions << { fund_class_id: nil, message: "SIX returned an error", status: error['k'], value: error['v'] }
+        @exceptions << { fund_class_id: nil, message: 'SIX returned an error', status: error['k'], value: error['v'] }
       end if response.errors?
       SIX::PriceList.new(response['IL']['I'])
     end

--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -17,7 +17,7 @@ module SIX
       if response['f'].to_i == 1
         SIX::Instrument.new(response['l'])
       else
-        raise Exception, "ISIN #{isin} isn't available on SIX listings"
+        raise ArgumentError, "ISIN #{isin} isn't available on SIX listings"
       end
     end
 
@@ -37,7 +37,7 @@ module SIX
           instruments_list = SIX::InstrumentList.new
           instruments_list.generate_instruments(valor_number, currency_code, markets_ids)
           result[fund_class[:id]] = fetch_prices(instruments_list).most_updated
-        rescue Exception => e
+        rescue => e
           @exceptions << { fund_class_id: fund_class, message: e.message }
           next
         end
@@ -65,7 +65,7 @@ module SIX
 
     def verify_isin_currency_existence(isin, currency)
       if isin.blank? or currency.blank?
-        raise Exception, "ISIN: #{isin} or Currency: #{currency} is empty!"
+        raise ArgumentError, "ISIN: #{isin} or Currency: #{currency} is empty!"
       end
     end
 

--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -29,15 +29,14 @@ module SIX
       six_currency = SIX::Currency.new
       fund_classes.each do |fund_class|
         begin
-        verify_isin_currency_existence(fund_class[:currency], fund_class[:currency])
-        currency_code = six_currency.find_code(fund_class[:currency].upcase)
-        instrument_id = identify_instrument(fund_class[:isin])
-        valor_number = instrument_id.valor
-        markets_ids = fetch_markets(valor_number, currency_code)
-        instruments_list = SIX::InstrumentList.new
-        instruments_list.generate_instruments(valor_number, currency_code, markets_ids)
-        result[fund_class[:id]] = fetch_prices(instruments_list).most_updated
-
+          verify_isin_currency_existence(fund_class[:currency], fund_class[:currency])
+          currency_code = six_currency.find_code(fund_class[:currency].upcase)
+          instrument_id = identify_instrument(fund_class[:isin])
+          valor_number = instrument_id.valor
+          markets_ids = fetch_markets(valor_number, currency_code)
+          instruments_list = SIX::InstrumentList.new
+          instruments_list.generate_instruments(valor_number, currency_code, markets_ids)
+          result[fund_class[:id]] = fetch_prices(instruments_list).most_updated
         rescue Exception => e
           @exceptions << { fund_class_id: fund_class, message: e.message }
           next
@@ -87,8 +86,6 @@ module SIX
       prices = request('getListingData', params)['IL']['I']
       SIX::PriceList.new(prices)
     end
-
-
 
     private
 

--- a/lib/six/errorable.rb
+++ b/lib/six/errorable.rb
@@ -1,19 +1,26 @@
 module SIX
   module Errorable
-    def error?
-      errorable_object['A'] && errorable_object['A']['k'] &&
-          errorable_object['A']['k'].match(/\Ae\d+\z/)
+    def errors?
+      # there's some error node with a "e1234"-like attribute 'k'
+      error_node.present? && error_node.any? { |e| e['k'].try(:=~, /\Ae\d+\z/) }
     end
 
     def raise_error!
-      fail SIX::Error, error
+      fail SIX::Error, errors
     end
 
-    def error
-      errorable_object['A']['v']
+    def errors
+      error_node if errors?
     end
 
     private
+
+    def error_node
+      # error nodes ('A') can be under 'XRF' or directly in 'A'
+      # e.g.
+      # "XRF"=>{"A"=>[{"k"=>"e0008", "v"=>"abc4855464,354,814"}, {"k"=>"e0008", "v"=>"def2241864,47,814"}]}
+      Array.wrap(errorable_object['A'] || errorable_object['XRF'].try(:[], 'A'))
+    end
 
     def errorable_object
       self

--- a/lib/six/instrument_list.rb
+++ b/lib/six/instrument_list.rb
@@ -2,10 +2,8 @@ module SIX
   class InstrumentList
     attr_accessor :instruments
 
-    def initialize(instruments_text = nil)
-      if instruments_text
-        @instruments = instruments_text.map{ |instrument| Instrument.new(instrument) }
-      end
+    def initialize(instruments = nil)
+      @instruments = instruments.map { |instrument| Instrument.new(instrument) } if instruments
     end
 
     # returns Array of Instrument
@@ -17,7 +15,15 @@ module SIX
 
     # returns Array of Array. where each Array contains [ik_index: instrument_id]
     def price_request_params
-      @instruments.map.with_index { |instrument, index| ["ik#{index+1}", instrument.value] }.to_h
+      @instruments.each.with_object({}).with_index do |(instrument, result), index|
+        result["ik#{index+1}"] = sanitize_identifier(instrument.value)
+      end
+    end
+
+    private
+
+    def sanitize_identifier(identifier)
+      identifier.gsub(/[^\d,]/, '')
     end
   end
 end

--- a/lib/six/price.rb
+++ b/lib/six/price.rb
@@ -11,8 +11,16 @@ module SIX
       data['v']
     end
 
+    def value?
+      value.present?
+    end
+
     def date
       data['d']
+    end
+
+    def status
+      data['s']
     end
   end
 end

--- a/lib/six/response.rb
+++ b/lib/six/response.rb
@@ -11,7 +11,6 @@ module SIX
 
     def validate!
       fail SIX::Error, body if code != 200
-      raise_error! if error?
     end
 
     def [](key)

--- a/lib/six/version.rb
+++ b/lib/six/version.rb
@@ -1,3 +1,3 @@
 module SIX
-  VERSION = '0.2.3'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
### [RV-2020](https://fundbase.atlassian.net/browse/RV-2020)

Preparations for changes which will be done in Fundbase repo.

### Solution

* sanitize instrument identifiers by keeping only digits and commands (which doesn't guarantee success, but at least prevents errors such as extra space)
* raise `ArgumentError` instead of `Exception`
* don't fail entire batch when there are errors; collect all errors