### PR TITLE
RV-2020 Improve SIX error handling

### DIFF
--- a/lib/six/client.rb
+++ b/lib/six/client.rb
@@ -57,7 +57,7 @@ module SIX
       end
 
       securities_with_instrument_id.each.with_object({}).with_index do |(security, result), index|
-        if prices[index].value?
+        if !prices[index].respond_to?(:value?) || prices[index].value?
           result[security[:id]] = prices[index]
         else
           @exceptions << { fund_class_id: security, message: "SIX didn't return a price", status: prices[index].status }


### PR DESCRIPTION
The `price.value?` check which was added breaks the Backcheck, because in that case, it's actually a list of prices; so only check it if it's a single price.